### PR TITLE
Add `.spec.secure` field to CRD

### DIFF
--- a/config/core/300-githubsource.yaml
+++ b/config/core/300-githubsource.yaml
@@ -234,6 +234,11 @@ spec:
                   oneOf:
                   - required: [ref]
                   - required: [uri]
+                secure:
+                  type: boolean
+                  description: Secure can be set to true to configure the
+                    webhook to use https, or false to use http. Omitting it relies
+                    on the scheme of the Knative Service created.
               required:
               - ownerAndRepository
               - eventTypes


### PR DESCRIPTION
## Proposed Changes

- :bug: we have the `.spec.secure` field defined in the GH source type, but don't have it in the CRD: https://github.com/knative-extensions/eventing-github/blob/ae3b7ca05fc11408e19c71a1038eadf1935f53c8/pkg/apis/sources/v1alpha1/githubsource_types.go#L84

This PR addresses it and adds it to the CRD.