### PR TITLE
fix: pass application context to adapter setup

### DIFF
--- a/cmd/receive_adapter/main.go
+++ b/cmd/receive_adapter/main.go
@@ -18,10 +18,14 @@ package main
 
 import (
 	"knative.dev/eventing/pkg/adapter/v2"
+	"knative.dev/pkg/signals"
 
 	githubadapter "knative.dev/eventing-github/pkg/adapter"
 )
 
 func main() {
-	adapter.Main("githubsource", githubadapter.NewEnvConfig, githubadapter.NewAdapter)
+	ctx := signals.NewContext()
+	ctx = adapter.WithInjectorEnabled(ctx)
+
+	adapter.MainWithContext(ctx, "githubsource", githubadapter.NewEnvConfig, githubadapter.NewAdapter)
 }


### PR DESCRIPTION
Fix the receive adapter to start without panic

@pierDipi as far as I can tell, the mt_receive_adapter should be fine since it uses `adapter.WithController()`. Do you think we also need the `adapter.WithInjectorEnabled()` call for that one as well?