### PR TITLE
cleanup: fix st1005 error (no capitalized error strings)

### DIFF
--- a/pkg/reconciler/source/githubsource.go
+++ b/pkg/reconciler/source/githubsource.go
@@ -228,7 +228,7 @@ func (r *Reconciler) reconcileReceiveAdapter(ctx context.Context, source *source
 			// Error was something other than NotFound
 			return nil, err
 		} else if !metav1.IsControlledBy(ksvc, source) {
-			return nil, fmt.Errorf("Service %q is not owned by GitHubSource %q", ksvc.Name, source.Name)
+			return nil, fmt.Errorf("service %q is not owned by GitHubSource %q", ksvc.Name, source.Name)
 		}
 		return ksvc, nil
 	}


### PR DESCRIPTION
Fixes the lint errors seen in https://github.com/knative-extensions/eventing-github/pull/595

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove the capital at the start of the error string on the offending line
